### PR TITLE
Sets entrypoint-service for rock

### DIFF
--- a/nfsplugin/4.7.0/rockcraft.yaml
+++ b/nfsplugin/4.7.0/rockcraft.yaml
@@ -25,9 +25,11 @@ services:
   nfsplugin:
     override: replace
     startup: enabled
-    command: "/nfsplugin"
+    command: "/nfsplugin [ --help ]"
     on-success: shutdown
     on-failure: shutdown
+
+entrypoint-service: nfsplugin
 
 parts:
   add-dependencies:


### PR DESCRIPTION
The NFS helm chart passes additional arguments to the container image, which should be passed to the binary itself. For this, we need to set the entrypoint-service, so Pebble will pass the arguments to the proper service.