### PR TITLE
Updates the nfsplugin rock

### DIFF
--- a/nfsplugin/4.7.0/rockcraft.yaml
+++ b/nfsplugin/4.7.0/rockcraft.yaml
@@ -11,7 +11,6 @@ version: 4.7.0
 
 base: bare
 build-base: ubuntu@22.04
-run-user: _daemon_
 
 platforms:
   amd64:
@@ -58,3 +57,8 @@ parts:
       - ./cmd/nfsplugin
     organize:
       bin/nfsplugin: ./
+    override-build: |
+      craftctl default
+
+      # nfsplugin requires the /tmp directory.
+      mkdir -p "${CRAFT_PART_INSTALL}/tmp"


### PR DESCRIPTION
The ``nfsplugin`` executable currently fails because it has no ``/tmp`` folder. Additionally, it fails when it tries to open files in the mentioned folder, or when trying to listen to ``unix:///csi/csi.sock``.